### PR TITLE
Surface anatomical element laterality

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,10 +49,11 @@
                 </select>
               </div>
               <div class="selector-group">
-                <label for="modelSelect" data-i18n="sidebar.modelLabel">Bone (3D Model)</label>
+                <label for="modelSelect" data-i18n="sidebar.modelLabel">Anatomical element</label>
                 <select id="modelSelect" disabled>
                   <option value="" data-i18n="sidebar.modelDisabledOption">Select a dataset</option>
                 </select>
+                <div id="elementLaterality" class="selector-note" hidden></div>
               </div>
               <div class="selector-group selector-group--compact">
                 <label for="reloadDatasets" data-i18n="sidebar.actionsLabel">Actions</label>
@@ -69,7 +70,7 @@
             <div class="external-links">
               <a id="gbifLink" class="external-link" href="#" target="_blank" rel="noopener noreferrer" hidden data-i18n="sidebar.links.gbif">Species (GBIF)</a>
               <a id="coraLink" class="external-link" href="#" target="_blank" rel="noopener noreferrer" hidden data-i18n="sidebar.links.cora">Species (CORA-RDR)</a>
-              <a id="uberonLink" class="external-link" href="#" target="_blank" rel="noopener noreferrer" hidden data-i18n="sidebar.links.uberon">Bone (OLS UBERON)</a>
+              <a id="uberonLink" class="external-link" href="#" target="_blank" rel="noopener noreferrer" hidden data-i18n="sidebar.links.uberon">Anatomical element (OLS UBERON)</a>
               <button id="aboutButton" type="button" class="external-link" data-i18n="sidebar.links.about">About the project</button>
               <div class="language-selector" role="group" aria-labelledby="languageSelectLabel">
                 <label id="languageSelectLabel" for="languageSelect" class="language-selector__label" data-i18n="language.selectorLabel">Language</label>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -184,6 +184,12 @@ body {
   cursor: not-allowed;
 }
 
+.selector-note {
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+  min-height: 1rem;
+}
+
 /* === Sidebar === */
 .sidebar {
   display: grid;

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -8,7 +8,7 @@
     "selectionHeading": "Selecció",
     "datasetLabel": "Espècie",
     "datasetLoadingOption": "Carregant conjunts de dades...",
-    "modelLabel": "Os (model 3D)",
+    "modelLabel": "Element anatòmic",
     "modelDisabledOption": "Selecciona un conjunt de dades",
     "actionsLabel": "Accions",
     "reloadButton": "Torna a carregar les llistes",
@@ -17,8 +17,17 @@
     "links": {
       "gbif": "Espècie (GBIF)",
       "cora": "Espècie (CORA-RDR)",
-      "uberon": "Os (OLS UBERON)",
+      "uberon": "Element anatòmic (OLS UBERON)",
       "about": "Sobre el projecte"
+    },
+    "laterality": {
+      "label": "Lateralitat",
+      "values": {
+        "left": "Esquerra",
+        "right": "Dreta",
+        "bilateral": "Bilateral",
+        "unknown": "No especificada"
+      }
     }
   },
   "language": {

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -8,7 +8,7 @@
     "selectionHeading": "Selection",
     "datasetLabel": "Species",
     "datasetLoadingOption": "Loading datasets...",
-    "modelLabel": "Bone (3D Model)",
+    "modelLabel": "Anatomical element",
     "modelDisabledOption": "Select a dataset",
     "actionsLabel": "Actions",
     "reloadButton": "Reload lists",
@@ -17,8 +17,17 @@
     "links": {
       "gbif": "Species (GBIF)",
       "cora": "Species (CORA-RDR)",
-      "uberon": "Bone (OLS UBERON)",
+      "uberon": "Anatomical element (OLS UBERON)",
       "about": "About the project"
+    },
+    "laterality": {
+      "label": "Laterality",
+      "values": {
+        "left": "Left",
+        "right": "Right",
+        "bilateral": "Bilateral",
+        "unknown": "Not specified"
+      }
     }
   },
   "language": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -8,7 +8,7 @@
     "selectionHeading": "Selección",
     "datasetLabel": "Especie",
     "datasetLoadingOption": "Cargando conjuntos de datos...",
-    "modelLabel": "Hueso (modelo 3D)",
+    "modelLabel": "Elemento anatómico",
     "modelDisabledOption": "Selecciona un conjunto de datos",
     "actionsLabel": "Acciones",
     "reloadButton": "Recargar listas",
@@ -17,8 +17,17 @@
     "links": {
       "gbif": "Especie (GBIF)",
       "cora": "Especie (CORA-RDR)",
-      "uberon": "Hueso (OLS UBERON)",
+      "uberon": "Elemento anatómico (OLS UBERON)",
       "about": "Acerca del proyecto"
+    },
+    "laterality": {
+      "label": "Lateralidad",
+      "values": {
+        "left": "Izquierdo",
+        "right": "Derecho",
+        "bilateral": "Bilateral",
+        "unknown": "No especificada"
+      }
     }
   },
   "language": {

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -8,7 +8,7 @@
     "selectionHeading": "Sélection",
     "datasetLabel": "Espèce",
     "datasetLoadingOption": "Chargement des jeux de données...",
-    "modelLabel": "Os (modèle 3D)",
+    "modelLabel": "Élément anatomique",
     "modelDisabledOption": "Sélectionnez un jeu de données",
     "actionsLabel": "Actions",
     "reloadButton": "Recharger les listes",
@@ -17,8 +17,17 @@
     "links": {
       "gbif": "Espèce (GBIF)",
       "cora": "Espèce (CORA-RDR)",
-      "uberon": "Os (OLS UBERON)",
+      "uberon": "Élément anatomique (OLS UBERON)",
       "about": "À propos du projet"
+    },
+    "laterality": {
+      "label": "Latéralité",
+      "values": {
+        "left": "Gauche",
+        "right": "Droite",
+        "bilateral": "Bilatéral",
+        "unknown": "Non précisée"
+      }
     }
   },
   "language": {

--- a/public/js/data/dataverseClient.js
+++ b/public/js/data/dataverseClient.js
@@ -75,6 +75,45 @@ function normalizeDirectoryParts(directoryLabel) {
 }
 
 /**
+ * Attempts to infer specimen laterality (left/right/bilateral) from common string tokens.
+ *
+ * @param {string[]} sources - Candidate strings describing the element.
+ * @returns {'left'|'right'|'bilateral'|null} Inferred laterality code.
+ */
+function inferLateralityFromStrings(sources = []) {
+  if (!sources.length) return null;
+
+  const text = sources
+    .filter(Boolean)
+    .map((value) =>
+      normalizeSlashes(String(value))
+        .replace(/[_\-]+/g, ' ')
+        .replace(/[()]/g, ' ')
+        .toLowerCase()
+    )
+    .join(' ');
+
+  if (!text) return null;
+
+  const bilateralPattern = /\b(bilateral|both sides?|pair(?:ed)?|double)\b/i;
+  if (bilateralPattern.test(text)) {
+    return 'bilateral';
+  }
+
+  const leftPattern = /\b(left|sinist(?:er|ra)|izquierd[ao]?|esquer(?:ra|re)|gauche)\b/i;
+  if (leftPattern.test(text)) {
+    return 'left';
+  }
+
+  const rightPattern = /\b(right|dex(?:ter|tra|tre)|derech[ao]?|dreta|destra|droite)\b/i;
+  if (rightPattern.test(text)) {
+    return 'right';
+  }
+
+  return null;
+}
+
+/**
  * Resolves a relative path against a dataset directory, handling traversal.
  *
  * @param {string} baseDir - Base directory to resolve from.
@@ -287,6 +326,13 @@ function buildModelIndex(files) {
       objEntry,
       mtlEntry,
       directory: directoryLabel,
+      laterality: inferLateralityFromStrings([
+        displayName,
+        directoryLabel,
+        objEntry?.file?.label,
+        objEntry?.path,
+        objEntry?.file?.description
+      ]),
     };
 
     models.push(model);

--- a/public/js/ui/interface.js
+++ b/public/js/ui/interface.js
@@ -14,6 +14,13 @@ import { i18n } from '../i18n/translator.js';
  */
 const translate = (key, fallback = '') => i18n.translate(key, { defaultValue: fallback });
 
+const LATERALITY_FALLBACKS = {
+  left: 'Left',
+  right: 'Right',
+  bilateral: 'Bilateral',
+  unknown: 'Not specified',
+};
+
 /**
  * Escapes arbitrary text for safe HTML insertion.
  *
@@ -776,6 +783,7 @@ export async function initInterface({
   const clearMeasurementsButton = documentRef.getElementById('clearMeasurements');
   const measurementOverlay = documentRef.getElementById('measurementOverlay');
   const languageSelect = documentRef.getElementById('languageSelect');
+  const lateralityIndicator = documentRef.getElementById('elementLaterality');
 
   if (!datasetSelect || !modelSelect || !reloadButton || !viewerContainer) {
     throw new Error('Required UI elements are missing');
@@ -795,6 +803,30 @@ export async function initInterface({
   resizeViewer();
 
   let lastStatus = null;
+  const modelLateralityByKey = new Map();
+  let currentLateralityCode = null;
+
+  const updateLateralityIndicator = (code) => {
+    if (!lateralityIndicator) {
+      return;
+    }
+    currentLateralityCode = code && code !== 'unknown' ? code : null;
+    if (!currentLateralityCode) {
+      lateralityIndicator.hidden = true;
+      lateralityIndicator.textContent = '';
+      return;
+    }
+    const labelText = translate('sidebar.laterality.label', 'Laterality');
+    const fallback = LATERALITY_FALLBACKS[currentLateralityCode] || currentLateralityCode;
+    const valueText = translate(
+      `sidebar.laterality.values.${currentLateralityCode}`,
+      fallback,
+    );
+    lateralityIndicator.textContent = `${labelText}: ${valueText}`;
+    lateralityIndicator.hidden = false;
+  };
+
+  updateLateralityIndicator(null);
 
   const setStatus = (key, type = 'loading') => {
     if (!statusBanner) return;
@@ -929,6 +961,7 @@ export async function initInterface({
     updateLightingButton();
     updateMeasureButton();
     i18n.applyTranslations(documentRef);
+    updateLateralityIndicator(currentLateralityCode);
   };
 
   let activeDatasetId = null;
@@ -989,6 +1022,8 @@ export async function initInterface({
     );
     modelSelect.innerHTML = `<option value="">${modelPlaceholder}</option>`;
     modelSelect.disabled = true;
+    modelLateralityByKey.clear();
+    updateLateralityIndicator(null);
     activeDatasetId = null;
     if (statusKey) {
       setStatus(statusKey, 'info');
@@ -1058,6 +1093,8 @@ export async function initInterface({
       renderDatasetMetadata(metadataPanel, null);
       currentMetadataDetail = null;
       updateExternalLinks(null, coraLink, gbifLink, uberonLink);
+      modelLateralityByKey.clear();
+      updateLateralityIndicator(null);
       setStatus('status.selectDatasetAndModel', 'info');
       return;
     }
@@ -1078,6 +1115,8 @@ export async function initInterface({
       updateExternalLinks(currentMetadataDetail, coraLink, gbifLink, uberonLink);
 
       if (!entry.models?.length) {
+        modelLateralityByKey.clear();
+        updateLateralityIndicator(null);
         const noModelsOption = escapeHtml(
           translate('selector.model.none', 'No OBJ/MTL model found'),
         );
@@ -1087,6 +1126,15 @@ export async function initInterface({
         return;
       }
 
+      modelLateralityByKey.clear();
+      entry.models.forEach((model) => {
+        if (!model || !model.key) {
+          return;
+        }
+        modelLateralityByKey.set(model.key, model.laterality || null);
+      });
+      updateLateralityIndicator(null);
+
       const chooseModelOption = escapeHtml(
         translate('selector.model.placeholder', 'Choose a model...'),
       );
@@ -1095,7 +1143,11 @@ export async function initInterface({
         entry.models
           .map(
             (model) =>
-              `<option value="${escapeHtml(model.key)}">${escapeHtml(model.displayName)}</option>`,
+              `<option value="${escapeHtml(model.key)}"${
+                model.laterality && model.laterality !== 'unknown'
+                  ? ` data-laterality="${escapeHtml(model.laterality)}"`
+                  : ''
+              }>${escapeHtml(model.displayName)}</option>`,
           )
           .join('');
 
@@ -1105,6 +1157,8 @@ export async function initInterface({
     } catch (error) {
       console.error(error);
       if (currentModelToken === modelToken) {
+        modelLateralityByKey.clear();
+        updateLateralityIndicator(null);
         const loadErrorOption = escapeHtml(
           translate('selector.model.error', 'Load error'),
         );
@@ -1128,6 +1182,7 @@ export async function initInterface({
       setStatus('status.loadingGeometry');
       const entry = await dataClient.ensureDatasetPrepared(persistentId);
       const modelInfo = entry.modelMap ? entry.modelMap.get(modelKey) : null;
+      updateLateralityIndicator(modelInfo?.laterality || modelLateralityByKey.get(modelKey) || null);
       const source = await dataClient.createModelSource(persistentId, modelKey);
       if (currentModelToken !== modelToken) {
         return;
@@ -1170,11 +1225,13 @@ export async function initInterface({
     if (!modelKey) {
       viewer.clear();
       setStatus('status.selectModel', 'info');
+      updateLateralityIndicator(null);
       const persistentId = datasetSelect.value;
       currentMetadataDetail = dataClient.getDatasetMetadata(persistentId) || currentMetadataDetail;
       updateExternalLinks(currentMetadataDetail, coraLink, gbifLink, uberonLink, null);
       return;
     }
+    updateLateralityIndicator(modelLateralityByKey.get(modelKey) || null);
     const persistentId = datasetSelect.value;
     loadModel(persistentId, modelKey);
   });


### PR DESCRIPTION
## Summary
- rename the bone selector/link copy to "Anatomical element" across locales
- infer laterality from dataset metadata and display it beside the selector
- plumb laterality through the Dataverse client so viewers stay in sync

Closes #6